### PR TITLE
feat: add --dry-run flag with grouped tree output

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -8,3 +8,6 @@ wheels/
 
 # Virtual environments
 .venv
+
+# Git worktrees
+.worktrees/

--- a/core/dry_run.py
+++ b/core/dry_run.py
@@ -1,0 +1,153 @@
+import os
+
+
+def render_dry_run_movies(main_files, extra_files, target_dir, downmix_audio, print_summary=True):
+    """Render dry-run output for movies as a grouped tree.
+
+    Returns (move_count, ffmpeg_count) so callers can aggregate for combined summaries.
+    Only prints the summary line if print_summary=True (default).
+    """
+    move_count = 0
+    ffmpeg_count = 0
+
+    # Group operations by movie folder
+    groups = {}
+    for file_info, target_path in main_files:
+        rel = os.path.relpath(target_path, target_dir)
+        parts = rel.split(os.sep)
+        folder = parts[0]
+        filename = os.sep.join(parts[1:])
+        if folder not in groups:
+            groups[folder] = []
+        label = "[COPY + FFMPEG]" if downmix_audio else "[MOVE]"
+        if downmix_audio:
+            ffmpeg_count += 1
+        else:
+            move_count += 1
+        groups[folder].append((filename, file_info["path"], label))
+
+    for file_info, target_path in extra_files:
+        rel = os.path.relpath(target_path, target_dir)
+        parts = rel.split(os.sep)
+        folder = parts[0]
+        filename = os.sep.join(parts[1:])
+        if folder not in groups:
+            groups[folder] = []
+        move_count += 1
+        groups[folder].append((filename, file_info["path"], "[MOVE]"))
+
+    # Print grouped tree
+    for folder in sorted(groups.keys()):
+        print(f"{folder}/")
+        entries = groups[folder]
+        # Collect subfolder structure
+        subfolders = {}
+        direct_files = []
+        for filename, source, label in entries:
+            parts = filename.split(os.sep)
+            if len(parts) > 1:
+                subfolder = parts[0]
+                subfile = os.sep.join(parts[1:])
+                if subfolder not in subfolders:
+                    subfolders[subfolder] = []
+                subfolders[subfolder].append((subfile, source, label))
+            else:
+                direct_files.append((filename, source, label))
+
+        for filename, source, label in direct_files:
+            print(f"  {filename}  <-  {source}  {label}")
+
+        for subfolder in sorted(subfolders.keys()):
+            print(f"  {subfolder}/")
+            for subfile, source, label in subfolders[subfolder]:
+                print(f"    {subfile}  <-  {source}  {label}")
+
+    if print_summary:
+        print_dry_run_summary(move_count, ffmpeg_count)
+
+    return move_count, ffmpeg_count
+
+
+def render_dry_run_tv(main_files, extra_files, target_dir, downmix_audio, print_summary=True):
+    """Render dry-run output for TV shows as a grouped tree.
+
+    Returns (move_count, ffmpeg_count) so callers can aggregate for combined summaries.
+    Only prints the summary line if print_summary=True (default).
+    """
+    move_count = 0
+    ffmpeg_count = 0
+
+    # Group by series -> season
+    series = {}
+    all_ops = []
+    for file_info, target_path in main_files:
+        label = "[COPY + FFMPEG]" if downmix_audio else "[MOVE]"
+        if downmix_audio:
+            ffmpeg_count += 1
+        else:
+            move_count += 1
+        all_ops.append((file_info, target_path, label))
+
+    for file_info, target_path in extra_files:
+        move_count += 1
+        all_ops.append((file_info, target_path, "[MOVE]"))
+
+    for file_info, target_path, label in all_ops:
+        rel = os.path.relpath(target_path, target_dir)
+        parts = rel.split(os.sep)
+        series_name = parts[0]
+        season_name = parts[1] if len(parts) > 1 else "Season 01"
+        filename = os.sep.join(parts[2:]) if len(parts) > 2 else parts[-1]
+
+        if series_name not in series:
+            series[series_name] = {}
+        if season_name not in series[series_name]:
+            series[series_name][season_name] = []
+        series[series_name][season_name].append((filename, file_info["path"], label))
+
+    for series_name in sorted(series.keys()):
+        print(f"{series_name}/")
+        for season_name in sorted(series[series_name].keys()):
+            print(f"  {season_name}/")
+            entries = series[series_name][season_name]
+            # Separate direct files from subfolder files (extras)
+            direct = []
+            subfolders = {}
+            for filename, source, label in entries:
+                parts = filename.split(os.sep)
+                if len(parts) > 1:
+                    sf = parts[0]
+                    sf_file = os.sep.join(parts[1:])
+                    if sf not in subfolders:
+                        subfolders[sf] = []
+                    subfolders[sf].append((sf_file, source, label))
+                else:
+                    direct.append((filename, source, label))
+
+            for filename, source, label in direct:
+                print(f"    {filename}  <-  {source}  {label}")
+
+            for sf in sorted(subfolders.keys()):
+                print(f"    {sf}/")
+                for sf_file, source, label in subfolders[sf]:
+                    print(f"      {sf_file}  <-  {source}  {label}")
+
+    if print_summary:
+        print_dry_run_summary(move_count, ffmpeg_count)
+
+    return move_count, ffmpeg_count
+
+
+def print_dry_run_summary(move_count, ffmpeg_count):
+    """Print summary line. Public so organize_mixed_content can call it for combined totals."""
+    parts = []
+    if move_count:
+        parts.append(f"{move_count} file{'s' if move_count != 1 else ''} would be moved")
+    if ffmpeg_count:
+        parts.append(
+            f"{ffmpeg_count} file{'s' if ffmpeg_count != 1 else ''} would be copied + processed with FFmpeg"
+        )
+    if parts:
+        print(f"\n{', '.join(parts)}")
+    else:
+        print("\nNo files to process")

--- a/core/movie_organizer.py
+++ b/core/movie_organizer.py
@@ -6,6 +6,7 @@ from collections import defaultdict
 
 from tqdm import tqdm
 
+from .dry_run import render_dry_run_movies
 from .file_processor import process_with_ffmpeg_async
 from .movie_parser import parse_movie_info
 
@@ -113,8 +114,6 @@ async def organize_movies(source_dir, target_dir, downmix_audio=False, dry_run=F
     When dry_run=True, returns (move_count, ffmpeg_count) tuple.
     Set print_summary=False when called from organize_mixed_content (which prints its own combined summary).
     """
-    from .dry_run import render_dry_run_movies
-
     # Scan source directory
     all_files = scan_source_directory(source_dir)
 

--- a/core/movie_organizer.py
+++ b/core/movie_organizer.py
@@ -46,16 +46,16 @@ def group_files_by_movie(all_files):
 
 
 def prepare_file_operations(movie_groups, target_dir):
-    """Prepare all file copy operations and return lists of main and extra files to process."""
+    """Prepare all file copy operations. Pure function — no filesystem access."""
     all_main_files = []
     all_extra_files = []
+    seen_targets = set()
 
     for key, files in movie_groups.items():
         title, year = re.match(r"^(.*?)(\d{4})?$", key).groups()
         year_str = f" ({year})" if year else ""
         folder_name = f"{title}{year_str}"
         movie_folder = os.path.join(target_dir, folder_name)
-        os.makedirs(movie_folder, exist_ok=True)
 
         # Separate main files and extras
         main_files = [f for f in files if not f["extra_type"]]
@@ -77,30 +77,31 @@ def prepare_file_operations(movie_groups, target_dir):
             target_file = f"{base_name}{os.path.splitext(file_info['file'])[1]}"
             target_path = os.path.join(movie_folder, target_file)
 
-            # Avoid overwrite by adding unique suffix if needed
-            if os.path.exists(target_path):
+            # Avoid collisions using in-memory tracking
+            if target_path in seen_targets:
                 base, ext = os.path.splitext(target_path)
                 counter = 1
-                while os.path.exists(f"{base}_{counter}{ext}"):
+                while f"{base}_{counter}{ext}" in seen_targets:
                     counter += 1
                 target_path = f"{base}_{counter}{ext}"
 
+            seen_targets.add(target_path)
             all_main_files.append((file_info, target_path))
 
         # Prepare extra files
         for file_info in extra_files:
             extra_folder = os.path.join(movie_folder, file_info["extra_type"])
-            os.makedirs(extra_folder, exist_ok=True)
             target_path = os.path.join(extra_folder, file_info["file"])
 
-            # Avoid overwrite
-            if os.path.exists(target_path):
+            # Avoid collisions using in-memory tracking
+            if target_path in seen_targets:
                 base, ext = os.path.splitext(target_path)
                 counter = 1
-                while os.path.exists(f"{base}_{counter}{ext}"):
+                while f"{base}_{counter}{ext}" in seen_targets:
                     counter += 1
                 target_path = f"{base}_{counter}{ext}"
 
+            seen_targets.add(target_path)
             all_extra_files.append((file_info, target_path))
 
     return all_main_files, all_extra_files
@@ -130,6 +131,10 @@ async def organize_movies(source_dir, target_dir, downmix_audio=False):
             os.makedirs(movie_folder, exist_ok=True)
 
     all_main_files, all_extra_files = prepare_file_operations(movie_groups, target_dir)
+
+    # Create extra folders (movie folders already created in the tqdm loop above)
+    for file_info, target_path in all_extra_files:
+        os.makedirs(os.path.dirname(target_path), exist_ok=True)
 
     # Copy or move main files
     action = "Copying" if downmix_audio else "Moving"

--- a/core/movie_organizer.py
+++ b/core/movie_organizer.py
@@ -107,20 +107,36 @@ def prepare_file_operations(movie_groups, target_dir):
     return all_main_files, all_extra_files
 
 
-async def organize_movies(source_dir, target_dir, downmix_audio=False):
-    """Organize movies from source to target in Jellyfin format."""
+async def organize_movies(source_dir, target_dir, downmix_audio=False, dry_run=False, print_summary=True):
+    """Organize movies from source to target in Jellyfin format.
+
+    When dry_run=True, returns (move_count, ffmpeg_count) tuple.
+    Set print_summary=False when called from organize_mixed_content (which prints its own combined summary).
+    """
+    from .dry_run import render_dry_run_movies
 
     # Scan source directory
     all_files = scan_source_directory(source_dir)
 
-    # Group files with progress bar
-    print("\nAnalyzing files...")
-    with tqdm(all_files, desc="Analyzing files") as pbar:
-        movie_groups = group_files_by_movie(all_files)
-        for _ in pbar:
-            pass
+    if not all_files:
+        if dry_run:
+            print(f"No video files found in {source_dir}")
+        return (0, 0) if dry_run else None
 
-    # Create directories and prepare operations
+    # Group files
+    movie_groups = group_files_by_movie(all_files)
+
+    # Prepare operations (pure — no filesystem access)
+    all_main_files, all_extra_files = prepare_file_operations(movie_groups, target_dir)
+
+    if dry_run:
+        return render_dry_run_movies(
+            all_main_files, all_extra_files, target_dir, downmix_audio,
+            print_summary=print_summary,
+        )
+
+    # --- Normal execution below ---
+    # Create directories
     print("\nCreating directories...")
     with tqdm(movie_groups.items(), desc="Creating folders") as pbar:
         for key, files in pbar:
@@ -130,9 +146,7 @@ async def organize_movies(source_dir, target_dir, downmix_audio=False):
             movie_folder = os.path.join(target_dir, folder_name)
             os.makedirs(movie_folder, exist_ok=True)
 
-    all_main_files, all_extra_files = prepare_file_operations(movie_groups, target_dir)
-
-    # Create extra folders (movie folders already created in the tqdm loop above)
+    # Create extra folders
     for file_info, target_path in all_extra_files:
         os.makedirs(os.path.dirname(target_path), exist_ok=True)
 
@@ -153,7 +167,7 @@ async def organize_movies(source_dir, target_dir, downmix_audio=False):
                 temp_path = f"{base}.temp{ext}"
                 ffmpeg_tasks.append((target_path, temp_path))
 
-    # Move extra files (extras are never FFmpeg-processed)
+    # Move extra files
     if all_extra_files:
         print("\nMoving extra files...")
         with tqdm(all_extra_files, desc="Moving extras") as pbar:

--- a/core/tv_organizer.py
+++ b/core/tv_organizer.py
@@ -5,6 +5,7 @@ from collections import defaultdict
 
 from tqdm import tqdm
 
+from .dry_run import render_dry_run_tv
 from .file_processor import process_with_ffmpeg_async
 from .tv_parser import get_real_extension, parse_tv_info
 
@@ -151,8 +152,6 @@ async def organize_tv_shows(source_dir, target_dir, downmix_audio=False, dry_run
     When dry_run=True, returns (move_count, ffmpeg_count) tuple.
     Set print_summary=False when called from organize_mixed_content (which prints its own combined summary).
     """
-    from .dry_run import render_dry_run_tv
-
     # Scan source directory
     all_files = scan_source_directory(source_dir)
 

--- a/core/tv_organizer.py
+++ b/core/tv_organizer.py
@@ -61,19 +61,16 @@ def group_files_by_series(all_files):
 
 
 def prepare_tv_operations(series_groups, target_dir):
-    """Prepare TV show file operations."""
+    """Prepare TV show file operations. Pure function — no filesystem access."""
     all_main_files = []
     all_extra_files = []
+    seen_targets = set()
 
     for series_key, seasons in series_groups.items():
-        # Create series folder
         series_folder = os.path.join(target_dir, series_key)
-        os.makedirs(series_folder, exist_ok=True)
 
         for season_num, files in seasons.items():
-            # Create season folder with zero-padding
             season_folder = os.path.join(series_folder, f"Season {season_num:02d}")
-            os.makedirs(season_folder, exist_ok=True)
 
             # Separate main files and extras
             main_files = [f for f in files if not f["extra_type"]]
@@ -85,19 +82,14 @@ def prepare_tv_operations(series_groups, target_dir):
                     file_info, series_key, season_num
                 )
                 target_path = os.path.join(season_folder, target_filename)
-
-                # Handle duplicates
-                target_path = handle_duplicate_files(target_path)
+                target_path = handle_duplicate_files(target_path, seen_targets)
                 all_main_files.append((file_info, target_path))
 
             # Process extra files
             for file_info in extra_files:
                 extra_folder = os.path.join(season_folder, file_info["extra_type"])
-                os.makedirs(extra_folder, exist_ok=True)
                 target_path = os.path.join(extra_folder, file_info["file"])
-
-                # Handle duplicates
-                target_path = handle_duplicate_files(target_path)
+                target_path = handle_duplicate_files(target_path, seen_targets)
                 all_extra_files.append((file_info, target_path))
 
     return all_main_files, all_extra_files
@@ -137,17 +129,20 @@ def generate_episode_filename(file_info, series_key, season_num):
     return f"{series_name} {season_str}{episode_str}{part_str}{resolution_str}{ext}"
 
 
-def handle_duplicate_files(target_path):
-    """Handle duplicate file names by adding counter."""
-    if not os.path.exists(target_path):
+def handle_duplicate_files(target_path, seen_targets):
+    """Handle duplicate file names using in-memory tracking."""
+    if target_path not in seen_targets:
+        seen_targets.add(target_path)
         return target_path
 
     base, ext = os.path.splitext(target_path)
     counter = 1
-    while os.path.exists(f"{base}_{counter}{ext}"):
+    while f"{base}_{counter}{ext}" in seen_targets:
         counter += 1
 
-    return f"{base}_{counter}{ext}"
+    result = f"{base}_{counter}{ext}"
+    seen_targets.add(result)
+    return result
 
 
 async def organize_tv_shows(source_dir, target_dir, downmix_audio=False):
@@ -175,6 +170,10 @@ async def organize_tv_shows(source_dir, target_dir, downmix_audio=False):
                 os.makedirs(season_folder, exist_ok=True)
 
     all_main_files, all_extra_files = prepare_tv_operations(series_groups, target_dir)
+
+    # Create extra folders (series/season folders already created in the tqdm loop above)
+    for file_info, target_path in all_extra_files:
+        os.makedirs(os.path.dirname(target_path), exist_ok=True)
 
     # Copy or move main files
     action = "Copying" if downmix_audio else "Moving"

--- a/core/tv_organizer.py
+++ b/core/tv_organizer.py
@@ -145,20 +145,37 @@ def handle_duplicate_files(target_path, seen_targets):
     return result
 
 
-async def organize_tv_shows(source_dir, target_dir, downmix_audio=False):
-    """Main TV show organization function."""
+async def organize_tv_shows(source_dir, target_dir, downmix_audio=False, dry_run=False, print_summary=True):
+    """Main TV show organization function.
+
+    When dry_run=True, returns (move_count, ffmpeg_count) tuple.
+    Set print_summary=False when called from organize_mixed_content (which prints its own combined summary).
+    """
+    from .dry_run import render_dry_run_tv
 
     # Scan source directory
     all_files = scan_source_directory(source_dir)
 
-    # Group files with progress bar
-    print("\nAnalyzing TV show files...")
-    with tqdm(all_files, desc="Analyzing files") as pbar:
-        series_groups = group_files_by_series(all_files)
-        for _ in pbar:
-            pass
+    if not all_files:
+        if dry_run:
+            print(f"No video files found in {source_dir}")
+        return (0, 0) if dry_run else None
 
-    # Create directories and prepare operations
+    # Group files
+    series_groups = group_files_by_series(all_files)
+
+    # Prepare operations (pure — no filesystem access)
+    all_main_files, all_extra_files = prepare_tv_operations(series_groups, target_dir)
+
+    if dry_run:
+        return render_dry_run_tv(
+            all_main_files, all_extra_files, target_dir, downmix_audio,
+            print_summary=print_summary,
+        )
+
+    # --- Normal execution below (existing code) ---
+
+    # Create directories
     print("\nCreating series and season directories...")
     with tqdm(series_groups.items(), desc="Creating folders") as pbar:
         for series_key, seasons in pbar:
@@ -169,9 +186,7 @@ async def organize_tv_shows(source_dir, target_dir, downmix_audio=False):
                 season_folder = os.path.join(series_folder, f"Season {season_num:02d}")
                 os.makedirs(season_folder, exist_ok=True)
 
-    all_main_files, all_extra_files = prepare_tv_operations(series_groups, target_dir)
-
-    # Create extra folders (series/season folders already created in the tqdm loop above)
+    # Create extra folders
     for file_info, target_path in all_extra_files:
         os.makedirs(os.path.dirname(target_path), exist_ok=True)
 
@@ -192,7 +207,7 @@ async def organize_tv_shows(source_dir, target_dir, downmix_audio=False):
                 temp_path = f"{base}.temp{ext}"
                 ffmpeg_tasks.append((target_path, temp_path))
 
-    # Move extra files (extras are never FFmpeg-processed)
+    # Move extra files
     if all_extra_files:
         print("\nMoving extra files...")
         with tqdm(all_extra_files, desc="Moving extras") as pbar:

--- a/docs/superpowers/plans/2026-03-16-dry-run.md
+++ b/docs/superpowers/plans/2026-03-16-dry-run.md
@@ -1,0 +1,1166 @@
+# `--dry-run` Implementation Plan
+
+> **For agentic workers:** REQUIRED: Use superpowers:subagent-driven-development (if subagents available) or superpowers:executing-plans to implement this plan. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Add a `--dry-run` flag that shows what file operations would occur without touching the filesystem, displayed as a grouped tree on stdout.
+
+**Architecture:** Refactor `prepare_file_operations()` and `prepare_tv_operations()` to be pure (no filesystem calls), add a `core/dry_run.py` renderer that formats operation lists as grouped trees, and thread a `dry_run` parameter through the CLI and organizer functions.
+
+**Tech Stack:** Python 3.13+, pytest, asyncio
+
+**Spec:** `docs/superpowers/specs/2026-03-16-dry-run-design.md`
+
+---
+
+## File Structure
+
+| File | Action | Responsibility |
+|------|--------|----------------|
+| `core/movie_organizer.py` | Modify | Remove filesystem calls from `prepare_file_operations()`, add `dry_run` param to `organize_movies()` |
+| `core/tv_organizer.py` | Modify | Remove filesystem calls from `prepare_tv_operations()` and `handle_duplicate_files()`, add `dry_run` param to `organize_tv_shows()` |
+| `core/dry_run.py` | Create | Renderer that formats operation lists as grouped tree output |
+| `jellyfin-renamer.py` | Modify | Add `--dry-run` argparse flag, thread through to organizers |
+| `test/test_renamer.py` | Modify | Add dry-run and pure-prepare tests |
+
+---
+
+## Chunk 1: Refactor prepare functions to be pure
+
+### Task 1: Make `prepare_file_operations()` pure (movie_organizer.py)
+
+**Files:**
+- Modify: `core/movie_organizer.py:48-106`
+- Test: `test/test_renamer.py`
+
+- [ ] **Step 1: Write failing test for pure `prepare_file_operations()`**
+
+Add to `test/test_renamer.py`:
+
+```python
+from core.movie_organizer import group_files_by_movie, prepare_file_operations
+
+
+def test_prepare_file_operations_is_pure(tmp_path):
+    """prepare_file_operations() should work without touching the filesystem."""
+    # Use a target dir that does NOT exist — proves no os.makedirs/os.path.exists
+    nonexistent_target = str(tmp_path / "nonexistent" / "deep" / "path")
+
+    all_files = [
+        (str(tmp_path), "Inception.2010.1080p.BluRay.mkv"),
+        (str(tmp_path), "Inception.2010.720p.BluRay.mkv"),
+    ]
+    movie_groups = group_files_by_movie(all_files)
+    main_files, extra_files = prepare_file_operations(movie_groups, nonexistent_target)
+
+    assert len(main_files) == 2
+    assert len(extra_files) == 0
+    # Target paths should be under the nonexistent target dir
+    for file_info, target_path in main_files:
+        assert target_path.startswith(nonexistent_target)
+    # The nonexistent dir should still not exist
+    assert not (tmp_path / "nonexistent").exists()
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `uv run python -m pytest test/test_renamer.py::test_prepare_file_operations_is_pure -v`
+Expected: FAIL (FileNotFoundError from `os.makedirs` or `os.path.exists` on nonexistent path)
+
+- [ ] **Step 3: Refactor `prepare_file_operations()` to remove filesystem calls**
+
+In `core/movie_organizer.py`, replace `prepare_file_operations()` (lines 48-106) with:
+
+```python
+def prepare_file_operations(movie_groups, target_dir):
+    """Prepare all file copy operations. Pure function — no filesystem access."""
+    all_main_files = []
+    all_extra_files = []
+    seen_targets = set()
+
+    for key, files in movie_groups.items():
+        title, year = re.match(r"^(.*?)(\d{4})?$", key).groups()
+        year_str = f" ({year})" if year else ""
+        folder_name = f"{title}{year_str}"
+        movie_folder = os.path.join(target_dir, folder_name)
+
+        # Separate main files and extras
+        main_files = [f for f in files if not f["extra_type"]]
+        extra_files = [f for f in files if f["extra_type"]]
+
+        # Prepare main files with target paths
+        version_counter = defaultdict(int)
+        for file_info in main_files:
+            res_str = f" - {file_info['resolution']}" if file_info["resolution"] else ""
+            part_str = f" - part{file_info['part']}" if file_info["part"] else ""
+            base_name = f"{folder_name}{res_str}{part_str}"
+
+            # Check for duplicates and add version if needed
+            version_key = f"{res_str}{part_str}"
+            version_counter[version_key] += 1
+            if len(main_files) > 1 and version_counter[version_key] > 1:
+                base_name += f" - version{version_counter[version_key]}"
+
+            target_file = f"{base_name}{os.path.splitext(file_info['file'])[1]}"
+            target_path = os.path.join(movie_folder, target_file)
+
+            # Avoid collisions using in-memory tracking
+            if target_path in seen_targets:
+                base, ext = os.path.splitext(target_path)
+                counter = 1
+                while f"{base}_{counter}{ext}" in seen_targets:
+                    counter += 1
+                target_path = f"{base}_{counter}{ext}"
+
+            seen_targets.add(target_path)
+            all_main_files.append((file_info, target_path))
+
+        # Prepare extra files
+        for file_info in extra_files:
+            extra_folder = os.path.join(movie_folder, file_info["extra_type"])
+            target_path = os.path.join(extra_folder, file_info["file"])
+
+            # Avoid collisions using in-memory tracking
+            if target_path in seen_targets:
+                base, ext = os.path.splitext(target_path)
+                counter = 1
+                while f"{base}_{counter}{ext}" in seen_targets:
+                    counter += 1
+                target_path = f"{base}_{counter}{ext}"
+
+            seen_targets.add(target_path)
+            all_extra_files.append((file_info, target_path))
+
+    return all_main_files, all_extra_files
+```
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `uv run python -m pytest test/test_renamer.py::test_prepare_file_operations_is_pure -v`
+Expected: PASS
+
+- [ ] **Step 5: Run full test suite to check for regressions**
+
+Run: `uv run python -m pytest test/test_renamer.py -v`
+Expected: All existing tests PASS
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add core/movie_organizer.py test/test_renamer.py
+git commit -m "refactor: make prepare_file_operations() pure — no filesystem access"
+```
+
+---
+
+### Task 2: Make `prepare_tv_operations()` and `handle_duplicate_files()` pure (tv_organizer.py)
+
+**Files:**
+- Modify: `core/tv_organizer.py:63-103,140-150`
+- Test: `test/test_renamer.py`
+
+- [ ] **Step 1: Write failing test for pure `prepare_tv_operations()`**
+
+Add to `test/test_renamer.py`:
+
+```python
+from core.tv_organizer import group_files_by_series, prepare_tv_operations
+
+
+def test_prepare_tv_operations_is_pure(tmp_path):
+    """prepare_tv_operations() should work without touching the filesystem."""
+    nonexistent_target = str(tmp_path / "nonexistent" / "deep" / "path")
+
+    all_files = [
+        (str(tmp_path), "Breaking.Bad.S01E01.720p.BluRay.x264.mkv"),
+        (str(tmp_path), "Breaking.Bad.S01E02.720p.BluRay.x264.mkv"),
+    ]
+    series_groups = group_files_by_series(all_files)
+    main_files, extra_files = prepare_tv_operations(series_groups, nonexistent_target)
+
+    assert len(main_files) == 2
+    assert len(extra_files) == 0
+    for file_info, target_path in main_files:
+        assert target_path.startswith(nonexistent_target)
+        assert "Season 01" in target_path
+    assert not (tmp_path / "nonexistent").exists()
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `uv run python -m pytest test/test_renamer.py::test_prepare_tv_operations_is_pure -v`
+Expected: FAIL (FileNotFoundError from `os.makedirs`)
+
+- [ ] **Step 3: Refactor `handle_duplicate_files()` to use in-memory tracking**
+
+Replace `handle_duplicate_files()` (lines 140-150) with a version that accepts a `seen_targets` set:
+
+```python
+def handle_duplicate_files(target_path, seen_targets):
+    """Handle duplicate file names using in-memory tracking."""
+    if target_path not in seen_targets:
+        seen_targets.add(target_path)
+        return target_path
+
+    base, ext = os.path.splitext(target_path)
+    counter = 1
+    while f"{base}_{counter}{ext}" in seen_targets:
+        counter += 1
+
+    result = f"{base}_{counter}{ext}"
+    seen_targets.add(result)
+    return result
+```
+
+- [ ] **Step 4: Refactor `prepare_tv_operations()` to remove filesystem calls**
+
+Replace `prepare_tv_operations()` (lines 63-103) with:
+
+```python
+def prepare_tv_operations(series_groups, target_dir):
+    """Prepare TV show file operations. Pure function — no filesystem access."""
+    all_main_files = []
+    all_extra_files = []
+    seen_targets = set()
+
+    for series_key, seasons in series_groups.items():
+        series_folder = os.path.join(target_dir, series_key)
+
+        for season_num, files in seasons.items():
+            season_folder = os.path.join(series_folder, f"Season {season_num:02d}")
+
+            # Separate main files and extras
+            main_files = [f for f in files if not f["extra_type"]]
+            extra_files = [f for f in files if f["extra_type"]]
+
+            # Process main files
+            for file_info in main_files:
+                target_filename = generate_episode_filename(
+                    file_info, series_key, season_num
+                )
+                target_path = os.path.join(season_folder, target_filename)
+                target_path = handle_duplicate_files(target_path, seen_targets)
+                all_main_files.append((file_info, target_path))
+
+            # Process extra files
+            for file_info in extra_files:
+                extra_folder = os.path.join(season_folder, file_info["extra_type"])
+                target_path = os.path.join(extra_folder, file_info["file"])
+                target_path = handle_duplicate_files(target_path, seen_targets)
+                all_extra_files.append((file_info, target_path))
+
+    return all_main_files, all_extra_files
+```
+
+- [ ] **Step 5: Run test to verify it passes**
+
+Run: `uv run python -m pytest test/test_renamer.py::test_prepare_tv_operations_is_pure -v`
+Expected: PASS
+
+- [ ] **Step 6: Run full test suite**
+
+Run: `uv run python -m pytest test/test_renamer.py -v`
+Expected: All tests PASS
+
+- [ ] **Step 7: Commit**
+
+```bash
+git add core/tv_organizer.py test/test_renamer.py
+git commit -m "refactor: make prepare_tv_operations() and handle_duplicate_files() pure"
+```
+
+---
+
+### Task 3: Test in-memory duplicate detection
+
+**Files:**
+- Test: `test/test_renamer.py`
+
+- [ ] **Step 1: Write test for movie duplicate detection**
+
+```python
+def test_movie_prepare_duplicate_detection(tmp_path):
+    """Duplicate movie files should get version suffixes via in-memory tracking."""
+    all_files = [
+        (str(tmp_path), "Inception.2010.1080p.BluRay.mkv"),
+        (str(tmp_path), "Inception.2010.1080p.WEB.mkv"),
+    ]
+    movie_groups = group_files_by_movie(all_files)
+    main_files, _ = prepare_file_operations(movie_groups, str(tmp_path / "target"))
+
+    paths = [t for _, t in main_files]
+    assert len(paths) == len(set(paths)), "All target paths should be unique"
+```
+
+- [ ] **Step 2: Write test for TV duplicate detection**
+
+```python
+from core.tv_organizer import handle_duplicate_files
+
+
+def test_tv_handle_duplicate_files_in_memory():
+    """handle_duplicate_files() should use in-memory set for dedup."""
+    seen = set()
+    path1 = handle_duplicate_files("/target/Show S01E01.mkv", seen)
+    path2 = handle_duplicate_files("/target/Show S01E01.mkv", seen)
+
+    assert path1 == "/target/Show S01E01.mkv"
+    assert path2 == "/target/Show S01E01_1.mkv"
+    assert path1 in seen
+    assert path2 in seen
+```
+
+- [ ] **Step 3: Run tests**
+
+Run: `uv run python -m pytest test/test_renamer.py::test_movie_prepare_duplicate_detection test/test_renamer.py::test_tv_handle_duplicate_files_in_memory -v`
+Expected: PASS
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add test/test_renamer.py
+git commit -m "test: add in-memory duplicate detection tests"
+```
+
+---
+
+## Chunk 2: Dry-run renderer and CLI integration
+
+### Task 4: Create `core/dry_run.py` renderer
+
+**Files:**
+- Create: `core/dry_run.py`
+- Test: `test/test_renamer.py`
+
+- [ ] **Step 1: Write failing test for movie dry-run output**
+
+```python
+from core.dry_run import render_dry_run_movies
+
+
+def test_dry_run_movie_output(tmp_path, capsys):
+    """Dry-run should print grouped tree for movies."""
+    all_files = [
+        (str(tmp_path), "Inception.2010.1080p.BluRay.mkv"),
+    ]
+    movie_groups = group_files_by_movie(all_files)
+    target = str(tmp_path / "target")
+    main_files, extra_files = prepare_file_operations(movie_groups, target)
+
+    render_dry_run_movies(main_files, extra_files, target, downmix_audio=False)
+
+    output = capsys.readouterr().out
+    assert "Inception (2010)/" in output
+    assert "[MOVE]" in output
+    assert "Inception.2010.1080p.BluRay.mkv" in output or "Inception (2010)" in output
+    assert "would be moved" in output
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `uv run python -m pytest test/test_renamer.py::test_dry_run_movie_output -v`
+Expected: FAIL (ImportError — module doesn't exist yet)
+
+- [ ] **Step 3: Implement `core/dry_run.py`**
+
+```python
+import os
+
+
+def render_dry_run_movies(main_files, extra_files, target_dir, downmix_audio, print_summary=True):
+    """Render dry-run output for movies as a grouped tree.
+
+    Returns (move_count, ffmpeg_count) so callers can aggregate for combined summaries.
+    Only prints the summary line if print_summary=True (default).
+    """
+    move_count = 0
+    ffmpeg_count = 0
+
+    # Group operations by movie folder
+    groups = {}
+    for file_info, target_path in main_files:
+        rel = os.path.relpath(target_path, target_dir)
+        parts = rel.split(os.sep)
+        folder = parts[0]
+        filename = os.sep.join(parts[1:])
+        if folder not in groups:
+            groups[folder] = []
+        label = "[COPY + FFMPEG]" if downmix_audio else "[MOVE]"
+        if downmix_audio:
+            ffmpeg_count += 1
+        else:
+            move_count += 1
+        groups[folder].append((filename, file_info["path"], label))
+
+    for file_info, target_path in extra_files:
+        rel = os.path.relpath(target_path, target_dir)
+        parts = rel.split(os.sep)
+        folder = parts[0]
+        filename = os.sep.join(parts[1:])
+        if folder not in groups:
+            groups[folder] = []
+        move_count += 1
+        groups[folder].append((filename, file_info["path"], "[MOVE]"))
+
+    # Print grouped tree
+    for folder in sorted(groups.keys()):
+        print(f"{folder}/")
+        entries = groups[folder]
+        # Collect subfolder structure
+        subfolders = {}
+        direct_files = []
+        for filename, source, label in entries:
+            parts = filename.split(os.sep)
+            if len(parts) > 1:
+                subfolder = parts[0]
+                subfile = os.sep.join(parts[1:])
+                if subfolder not in subfolders:
+                    subfolders[subfolder] = []
+                subfolders[subfolder].append((subfile, source, label))
+            else:
+                direct_files.append((filename, source, label))
+
+        for filename, source, label in direct_files:
+            print(f"  {filename}  <-  {source}  {label}")
+
+        for subfolder in sorted(subfolders.keys()):
+            print(f"  {subfolder}/")
+            for subfile, source, label in subfolders[subfolder]:
+                print(f"    {subfile}  <-  {source}  {label}")
+
+    if print_summary:
+        print_dry_run_summary(move_count, ffmpeg_count)
+
+    return move_count, ffmpeg_count
+
+
+def render_dry_run_tv(main_files, extra_files, target_dir, downmix_audio, print_summary=True):
+    """Render dry-run output for TV shows as a grouped tree.
+
+    Returns (move_count, ffmpeg_count) so callers can aggregate for combined summaries.
+    Only prints the summary line if print_summary=True (default).
+    """
+    move_count = 0
+    ffmpeg_count = 0
+
+    # Group by series -> season
+    series = {}
+    all_ops = []
+    for file_info, target_path in main_files:
+        label = "[COPY + FFMPEG]" if downmix_audio else "[MOVE]"
+        if downmix_audio:
+            ffmpeg_count += 1
+        else:
+            move_count += 1
+        all_ops.append((file_info, target_path, label))
+
+    for file_info, target_path in extra_files:
+        move_count += 1
+        all_ops.append((file_info, target_path, "[MOVE]"))
+
+    for file_info, target_path, label in all_ops:
+        rel = os.path.relpath(target_path, target_dir)
+        parts = rel.split(os.sep)
+        series_name = parts[0]
+        season_name = parts[1] if len(parts) > 1 else "Season 01"
+        filename = os.sep.join(parts[2:]) if len(parts) > 2 else parts[-1]
+
+        if series_name not in series:
+            series[series_name] = {}
+        if season_name not in series[series_name]:
+            series[series_name][season_name] = []
+        series[series_name][season_name].append((filename, file_info["path"], label))
+
+    for series_name in sorted(series.keys()):
+        print(f"{series_name}/")
+        for season_name in sorted(series[series_name].keys()):
+            print(f"  {season_name}/")
+            entries = series[series_name][season_name]
+            # Separate direct files from subfolder files (extras)
+            direct = []
+            subfolders = {}
+            for filename, source, label in entries:
+                parts = filename.split(os.sep)
+                if len(parts) > 1:
+                    sf = parts[0]
+                    sf_file = os.sep.join(parts[1:])
+                    if sf not in subfolders:
+                        subfolders[sf] = []
+                    subfolders[sf].append((sf_file, source, label))
+                else:
+                    direct.append((filename, source, label))
+
+            for filename, source, label in direct:
+                print(f"    {filename}  <-  {source}  {label}")
+
+            for sf in sorted(subfolders.keys()):
+                print(f"    {sf}/")
+                for sf_file, source, label in subfolders[sf]:
+                    print(f"      {sf_file}  <-  {source}  {label}")
+
+    if print_summary:
+        print_dry_run_summary(move_count, ffmpeg_count)
+
+    return move_count, ffmpeg_count
+
+
+def print_dry_run_summary(move_count, ffmpeg_count):
+    """Print summary line. Public so organize_mixed_content can call it for combined totals."""
+    parts = []
+    if move_count:
+        parts.append(f"{move_count} file{'s' if move_count != 1 else ''} would be moved")
+    if ffmpeg_count:
+        parts.append(
+            f"{ffmpeg_count} file{'s' if ffmpeg_count != 1 else ''} would be copied + processed with FFmpeg"
+        )
+    if parts:
+        print(f"\n{', '.join(parts)}")
+    else:
+        print("\nNo files to process")
+```
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `uv run python -m pytest test/test_renamer.py::test_dry_run_movie_output -v`
+Expected: PASS
+
+- [ ] **Step 5: Write test for TV dry-run output**
+
+```python
+from core.dry_run import render_dry_run_tv
+
+
+def test_dry_run_tv_output(tmp_path, capsys):
+    """Dry-run should print grouped tree for TV shows."""
+    all_files = [
+        (str(tmp_path), "Breaking.Bad.S01E01.720p.BluRay.x264.mkv"),
+        (str(tmp_path), "Breaking.Bad.S01E02.720p.BluRay.x264.mkv"),
+    ]
+    series_groups = group_files_by_series(all_files)
+    target = str(tmp_path / "target")
+    main_files, extra_files = prepare_tv_operations(series_groups, target)
+
+    render_dry_run_tv(main_files, extra_files, target, downmix_audio=False)
+
+    output = capsys.readouterr().out
+    assert "Breaking Bad/" in output
+    assert "Season 01/" in output
+    assert "[MOVE]" in output
+    assert "would be moved" in output
+```
+
+- [ ] **Step 6: Write test for downmix-audio labels**
+
+```python
+def test_dry_run_ffmpeg_labels(tmp_path, capsys):
+    """Dry-run with downmix_audio should show [COPY + FFMPEG] for main files."""
+    all_files = [
+        (str(tmp_path), "Inception.2010.1080p.BluRay.mkv"),
+    ]
+    movie_groups = group_files_by_movie(all_files)
+    target = str(tmp_path / "target")
+    main_files, extra_files = prepare_file_operations(movie_groups, target)
+
+    render_dry_run_movies(main_files, extra_files, target, downmix_audio=True)
+
+    output = capsys.readouterr().out
+    assert "[COPY + FFMPEG]" in output
+    assert "would be copied + processed with FFmpeg" in output
+```
+
+- [ ] **Step 7: Write test for extras always showing `[MOVE]` even with `--downmix-audio`**
+
+```python
+def test_dry_run_extras_always_move(tmp_path, capsys):
+    """Extras should show [MOVE] even when downmix_audio is True."""
+    all_files = [
+        (str(tmp_path), "Inception.2010.1080p.BluRay.mkv"),
+        (str(tmp_path), "The Matrix (1999) 1080p - Trailer.mkv"),
+    ]
+    movie_groups = group_files_by_movie(all_files)
+    target = str(tmp_path / "target")
+    main_files, extra_files = prepare_file_operations(movie_groups, target)
+
+    render_dry_run_movies(main_files, extra_files, target, downmix_audio=True)
+
+    output = capsys.readouterr().out
+    # Main files get COPY + FFMPEG
+    assert "[COPY + FFMPEG]" in output
+    # Find the trailers line — it should say [MOVE], not [COPY + FFMPEG]
+    for line in output.splitlines():
+        if "trailers/" in line.lower() or ("Trailer" in line and "<-" in line):
+            assert "[MOVE]" in line, f"Extras should always be [MOVE], got: {line}"
+```
+
+- [ ] **Step 8: Write test for extras subfolder rendering**
+
+```python
+def test_dry_run_extras_subfolder_tree(tmp_path, capsys):
+    """Extras should appear under their subfolder in the tree."""
+    all_files = [
+        (str(tmp_path), "The Matrix (1999) 1080p - Trailer.mkv"),
+    ]
+    movie_groups = group_files_by_movie(all_files)
+    target = str(tmp_path / "target")
+    main_files, extra_files = prepare_file_operations(movie_groups, target)
+
+    render_dry_run_movies(main_files, extra_files, target, downmix_audio=False)
+
+    output = capsys.readouterr().out
+    assert "trailers/" in output.lower()
+```
+
+- [ ] **Step 9: Run all new tests**
+
+Run: `uv run python -m pytest test/test_renamer.py -k "dry_run" -v`
+Expected: All PASS
+
+- [ ] **Step 10: Commit**
+
+```bash
+git add core/dry_run.py test/test_renamer.py
+git commit -m "feat: add dry-run renderer with grouped tree output"
+```
+
+---
+
+### Task 5: Add `dry_run` parameter to organizer functions
+
+**Files:**
+- Modify: `core/movie_organizer.py:109-183`
+- Modify: `core/tv_organizer.py:153-228`
+- Test: `test/test_renamer.py`
+
+- [ ] **Step 1: Write failing test for movie dry-run (zero side effects)**
+
+```python
+@pytest.mark.asyncio
+async def test_movie_dry_run_no_side_effects(tmp_path):
+    """Dry-run should not create any files or directories."""
+    source_dir = tmp_path / "source"
+    target_dir = tmp_path / "target"
+    source_dir.mkdir()
+    target_dir.mkdir()
+
+    # Create a dummy video file
+    (source_dir / "Inception.2010.1080p.BluRay.mkv").write_bytes(b"\x00" * 100)
+
+    await organize_movies(str(source_dir), str(target_dir), dry_run=True)
+
+    # Target should be empty
+    assert list(target_dir.iterdir()) == []
+    # Source file should still exist (not moved)
+    assert (source_dir / "Inception.2010.1080p.BluRay.mkv").exists()
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `uv run python -m pytest test/test_renamer.py::test_movie_dry_run_no_side_effects -v`
+Expected: FAIL (TypeError — `organize_movies()` doesn't accept `dry_run` yet)
+
+- [ ] **Step 3: Add `dry_run` to `organize_movies()`**
+
+In `core/movie_organizer.py`, modify `organize_movies()`:
+
+```python
+async def organize_movies(source_dir, target_dir, downmix_audio=False, dry_run=False, print_summary=True):
+    """Organize movies from source to target in Jellyfin format.
+
+    When dry_run=True, returns (move_count, ffmpeg_count) tuple.
+    Set print_summary=False when called from organize_mixed_content (which prints its own combined summary).
+    """
+    from .dry_run import render_dry_run_movies
+
+    # Scan source directory
+    all_files = scan_source_directory(source_dir)
+
+    if not all_files:
+        if dry_run:
+            print(f"No video files found in {source_dir}")
+        return (0, 0) if dry_run else None
+
+    # Group files
+    movie_groups = group_files_by_movie(all_files)
+
+    # Prepare operations (pure — no filesystem access)
+    all_main_files, all_extra_files = prepare_file_operations(movie_groups, target_dir)
+
+    if dry_run:
+        return render_dry_run_movies(
+            all_main_files, all_extra_files, target_dir, downmix_audio,
+            print_summary=print_summary,
+        )
+
+    # --- Normal execution below ---
+    # Note: The "Analyzing files" tqdm loop from the original code is removed —
+    # it was redundant (grouping happens in a single call, not per-item).
+    # The prepare_file_operations call is moved above the dry-run branch.
+    # Directory creation (below) now happens AFTER prepare, not inside it.
+
+    # Create directories
+    print("\nCreating directories...")
+    with tqdm(movie_groups.items(), desc="Creating folders") as pbar:
+        for key, files in pbar:
+            title, year = re.match(r"^(.*?)(\d{4})?$", key).groups()
+            year_str = f" ({year})" if year else ""
+            folder_name = f"{title}{year_str}"
+            movie_folder = os.path.join(target_dir, folder_name)
+            os.makedirs(movie_folder, exist_ok=True)
+
+    # Create extra folders
+    for file_info, target_path in all_extra_files:
+        os.makedirs(os.path.dirname(target_path), exist_ok=True)
+
+    # Copy or move main files
+    action = "Copying" if downmix_audio else "Moving"
+    print(f"\n{action} and renaming main files...")
+
+    ffmpeg_tasks = []
+    with tqdm(all_main_files, desc=f"{action} main files") as pbar:
+        for file_info, target_path in pbar:
+            if downmix_audio:
+                shutil.copy2(file_info["path"], target_path)
+            else:
+                shutil.move(file_info["path"], target_path)
+
+            if downmix_audio:
+                base, ext = os.path.splitext(target_path)
+                temp_path = f"{base}.temp{ext}"
+                ffmpeg_tasks.append((target_path, temp_path))
+
+    # Move extra files
+    if all_extra_files:
+        print("\nMoving extra files...")
+        with tqdm(all_extra_files, desc="Moving extras") as pbar:
+            for file_info, target_path in pbar:
+                shutil.move(file_info["path"], target_path)
+
+    # Process with FFmpeg if needed
+    if downmix_audio and ffmpeg_tasks:
+        print(
+            f"\nProcessing {len(ffmpeg_tasks)} file(s) with FFmpeg (max 2 concurrent)..."
+        )
+
+        semaphore = asyncio.Semaphore(2)
+
+        async def process_single_file(original_path, temp_path, pbar):
+            async with semaphore:
+                success = await process_with_ffmpeg_async(
+                    original_path, temp_path, pbar
+                )
+                if success:
+                    os.replace(temp_path, original_path)
+                else:
+                    if os.path.exists(temp_path):
+                        os.remove(temp_path)
+
+        with tqdm(total=len(ffmpeg_tasks), desc="FFmpeg processing") as pbar:
+            tasks = [
+                process_single_file(original_path, temp_path, pbar)
+                for original_path, temp_path in ffmpeg_tasks
+            ]
+            await asyncio.gather(*tasks)
+```
+
+Note: The "Analyzing files" tqdm loop was redundant (it just iterated the pbar without doing work — grouping happens in one call). Remove it. The directory creation tqdm loop is kept for normal mode, removed for dry-run by the early return.
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `uv run python -m pytest test/test_renamer.py::test_movie_dry_run_no_side_effects -v`
+Expected: PASS
+
+- [ ] **Step 5: Write failing test for TV dry-run (zero side effects)**
+
+```python
+@pytest.mark.asyncio
+async def test_tv_dry_run_no_side_effects(tmp_path):
+    """Dry-run should not create any files or directories."""
+    source_dir = tmp_path / "source"
+    target_dir = tmp_path / "target"
+    source_dir.mkdir()
+    target_dir.mkdir()
+
+    (source_dir / "Breaking.Bad.S01E01.720p.BluRay.x264.mkv").write_bytes(b"\x00" * 100)
+
+    await organize_tv_shows(str(source_dir), str(target_dir), dry_run=True)
+
+    assert list(target_dir.iterdir()) == []
+    assert (source_dir / "Breaking.Bad.S01E01.720p.BluRay.x264.mkv").exists()
+```
+
+- [ ] **Step 6: Add `dry_run` to `organize_tv_shows()`**
+
+Apply the same pattern as movies in `core/tv_organizer.py`:
+
+```python
+async def organize_tv_shows(source_dir, target_dir, downmix_audio=False, dry_run=False, print_summary=True):
+    """Main TV show organization function.
+
+    When dry_run=True, returns (move_count, ffmpeg_count) tuple.
+    Set print_summary=False when called from organize_mixed_content (which prints its own combined summary).
+    """
+    from .dry_run import render_dry_run_tv
+
+    # Scan source directory
+    all_files = scan_source_directory(source_dir)
+
+    if not all_files:
+        if dry_run:
+            print(f"No video files found in {source_dir}")
+        return (0, 0) if dry_run else None
+
+    # Group files
+    series_groups = group_files_by_series(all_files)
+
+    # Prepare operations (pure — no filesystem access)
+    all_main_files, all_extra_files = prepare_tv_operations(series_groups, target_dir)
+
+    if dry_run:
+        return render_dry_run_tv(
+            all_main_files, all_extra_files, target_dir, downmix_audio,
+            print_summary=print_summary,
+        )
+
+    # --- Normal execution below (existing code) ---
+
+    # Create directories
+    print("\nCreating series and season directories...")
+    with tqdm(series_groups.items(), desc="Creating folders") as pbar:
+        for series_key, seasons in pbar:
+            series_folder = os.path.join(target_dir, series_key)
+            os.makedirs(series_folder, exist_ok=True)
+
+            for season_num in seasons.keys():
+                season_folder = os.path.join(series_folder, f"Season {season_num:02d}")
+                os.makedirs(season_folder, exist_ok=True)
+
+    # Create extra folders
+    for file_info, target_path in all_extra_files:
+        os.makedirs(os.path.dirname(target_path), exist_ok=True)
+
+    # Copy or move main files
+    action = "Copying" if downmix_audio else "Moving"
+    print(f"\n{action} and renaming episode files...")
+
+    ffmpeg_tasks = []
+    with tqdm(all_main_files, desc=f"{action} episodes") as pbar:
+        for file_info, target_path in pbar:
+            if downmix_audio:
+                shutil.copy2(file_info["path"], target_path)
+            else:
+                shutil.move(file_info["path"], target_path)
+
+            if downmix_audio:
+                base, ext = os.path.splitext(target_path)
+                temp_path = f"{base}.temp{ext}"
+                ffmpeg_tasks.append((target_path, temp_path))
+
+    # Move extra files
+    if all_extra_files:
+        print("\nMoving extra files...")
+        with tqdm(all_extra_files, desc="Moving extras") as pbar:
+            for file_info, target_path in pbar:
+                shutil.move(file_info["path"], target_path)
+
+    # Process with FFmpeg if needed
+    if downmix_audio and ffmpeg_tasks:
+        print(
+            f"\nProcessing {len(ffmpeg_tasks)} file(s) with FFmpeg (max 2 concurrent)..."
+        )
+
+        semaphore = asyncio.Semaphore(2)
+
+        async def process_single_file(original_path, temp_path, pbar):
+            async with semaphore:
+                success = await process_with_ffmpeg_async(
+                    original_path, temp_path, pbar
+                )
+                if success:
+                    os.replace(temp_path, original_path)
+                else:
+                    if os.path.exists(temp_path):
+                        os.remove(temp_path)
+
+        with tqdm(total=len(ffmpeg_tasks), desc="FFmpeg processing") as pbar:
+            tasks = [
+                process_single_file(original_path, temp_path, pbar)
+                for original_path, temp_path in ffmpeg_tasks
+            ]
+            await asyncio.gather(*tasks)
+```
+
+- [ ] **Step 7: Run tests**
+
+Run: `uv run python -m pytest test/test_renamer.py::test_tv_dry_run_no_side_effects test/test_renamer.py::test_movie_dry_run_no_side_effects -v`
+Expected: PASS
+
+- [ ] **Step 8: Run full test suite**
+
+Run: `uv run python -m pytest test/test_renamer.py -v`
+Expected: All PASS
+
+- [ ] **Step 9: Commit**
+
+```bash
+git add core/movie_organizer.py core/tv_organizer.py test/test_renamer.py
+git commit -m "feat: add dry_run parameter to organize_movies() and organize_tv_shows()"
+```
+
+---
+
+### Task 6: Add `--dry-run` CLI flag and wire up `organize_mixed_content`
+
+**Files:**
+- Modify: `jellyfin-renamer.py`
+- Test: `test/test_renamer.py`
+
+- [ ] **Step 1: Write test for no-files-found edge case**
+
+```python
+@pytest.mark.asyncio
+async def test_dry_run_no_files_found(tmp_path, capsys):
+    """Dry-run on empty source should print 'No video files found'."""
+    source_dir = tmp_path / "source"
+    target_dir = tmp_path / "target"
+    source_dir.mkdir()
+    target_dir.mkdir()
+
+    await organize_movies(str(source_dir), str(target_dir), dry_run=True)
+
+    output = capsys.readouterr().out
+    assert "No video files found" in output
+```
+
+- [ ] **Step 2: Run test — should already pass from Task 5 implementation**
+
+Run: `uv run python -m pytest test/test_renamer.py::test_dry_run_no_files_found -v`
+Expected: PASS
+
+- [ ] **Step 3: Add `--dry-run` to argparse and update `organize_mixed_content`**
+
+In `jellyfin-renamer.py`:
+
+```python
+import argparse
+import asyncio
+import os
+
+from core.common import scan_source_directory
+from core.dry_run import print_dry_run_summary
+from core.movie_organizer import organize_movies
+from core.tv_organizer import organize_tv_shows
+
+
+async def organize_mixed_content(source_dir, target_dir, downmix_audio=False, dry_run=False):
+    """Organize mixed content by auto-detecting content type."""
+    if not dry_run:
+        print("Scanning for mixed content...")
+
+    # Scan files and auto-detect content types
+    all_files = scan_source_directory(source_dir, content_type="auto")
+
+    if not all_files:
+        if dry_run:
+            print(f"No video files found in {source_dir}")
+        return
+
+    # Separate files by detected type
+    movie_files = [
+        (root, file)
+        for root, file, content_type in all_files
+        if content_type == "movie"
+    ]
+    tv_files = [
+        (root, file) for root, file, content_type in all_files if content_type == "tv"
+    ]
+
+    if not dry_run:
+        print(f"Found {len(movie_files)} movie files and {len(tv_files)} TV show files")
+
+    # Create separate target directories
+    movies_dir = os.path.join(target_dir, "Movies")
+    shows_dir = os.path.join(target_dir, "Shows")
+
+    total_move = 0
+    total_ffmpeg = 0
+
+    # Process movies if found
+    if movie_files:
+        if not dry_run:
+            os.makedirs(movies_dir, exist_ok=True)
+            print("\n=== Processing Movies ===")
+        else:
+            print("=== Movies ===\n")
+        result = await organize_movies(
+            source_dir, movies_dir, downmix_audio,
+            dry_run=dry_run, print_summary=not dry_run,
+        )
+        if dry_run and result:
+            total_move += result[0]
+            total_ffmpeg += result[1]
+
+    # Process TV shows if found
+    if tv_files:
+        if not dry_run:
+            os.makedirs(shows_dir, exist_ok=True)
+            print("\n=== Processing TV Shows ===")
+        else:
+            print("\n=== TV Shows ===\n")
+        result = await organize_tv_shows(
+            source_dir, shows_dir, downmix_audio,
+            dry_run=dry_run, print_summary=not dry_run,
+        )
+        if dry_run and result:
+            total_move += result[0]
+            total_ffmpeg += result[1]
+
+    # Print combined summary for auto mode
+    if dry_run:
+        print_dry_run_summary(total_move, total_ffmpeg)
+
+
+if __name__ == "__main__":
+    parser = argparse.ArgumentParser(description="Organize media files for Jellyfin.")
+    parser.add_argument("source_dir", help="Source directory")
+    parser.add_argument("target_dir", help="Target directory")
+    parser.add_argument(
+        "--content-type",
+        choices=["movies", "tv", "auto"],
+        default="auto",
+        help="Type of content to process (default: auto)",
+    )
+    parser.add_argument(
+        "--downmix-audio",
+        action="store_true",
+        default=False,
+        help="Downmix audio to stereo FLAC using FFmpeg (default: False)",
+    )
+    parser.add_argument(
+        "--dry-run",
+        action="store_true",
+        default=False,
+        help="Show what would be done without making any changes",
+    )
+    args = parser.parse_args()
+
+    if args.content_type == "movies":
+        asyncio.run(
+            organize_movies(args.source_dir, args.target_dir, args.downmix_audio, dry_run=args.dry_run)
+        )
+    elif args.content_type == "tv":
+        asyncio.run(
+            organize_tv_shows(args.source_dir, args.target_dir, args.downmix_audio, dry_run=args.dry_run)
+        )
+    else:  # auto
+        asyncio.run(
+            organize_mixed_content(args.source_dir, args.target_dir, args.downmix_audio, dry_run=args.dry_run)
+        )
+```
+
+- [ ] **Step 4: Write test for auto-mode dry-run with combined summary**
+
+```python
+from jellyfin_renamer import organize_mixed_content
+
+
+@pytest.mark.asyncio
+async def test_dry_run_auto_mode(tmp_path, capsys):
+    """Auto mode dry-run should show headings and a combined summary."""
+    source_dir = tmp_path / "source"
+    target_dir = tmp_path / "target"
+    source_dir.mkdir()
+    target_dir.mkdir()
+
+    # Create a movie file and a TV file
+    (source_dir / "Inception.2010.1080p.BluRay.mkv").write_bytes(b"\x00" * 100)
+    (source_dir / "Breaking.Bad.S01E01.720p.BluRay.x264.mkv").write_bytes(b"\x00" * 100)
+
+    await organize_mixed_content(str(source_dir), str(target_dir), dry_run=True)
+
+    output = capsys.readouterr().out
+    assert "=== Movies ===" in output
+    assert "=== TV Shows ===" in output
+    assert "would be moved" in output
+    # Should be one combined summary, not two
+    assert output.count("would be moved") == 1
+    # Target should be empty
+    assert list(target_dir.iterdir()) == []
+```
+
+Note: This test imports `organize_mixed_content` from the main module. If the import path differs (e.g., the file is `jellyfin-renamer.py` with a hyphen), use `importlib` or rename the import. Alternatively, test via subprocess:
+
+```python
+import subprocess
+
+def test_dry_run_auto_mode_cli(tmp_path):
+    """Auto mode dry-run via CLI should show headings and combined summary."""
+    source_dir = tmp_path / "source"
+    target_dir = tmp_path / "target"
+    source_dir.mkdir()
+    target_dir.mkdir()
+
+    (source_dir / "Inception.2010.1080p.BluRay.mkv").write_bytes(b"\x00" * 100)
+    (source_dir / "Breaking.Bad.S01E01.720p.BluRay.x264.mkv").write_bytes(b"\x00" * 100)
+
+    result = subprocess.run(
+        ["uv", "run", "python", "jellyfin-renamer.py", str(source_dir), str(target_dir), "--dry-run"],
+        capture_output=True, text=True,
+    )
+    assert result.returncode == 0
+    assert "=== Movies ===" in result.stdout
+    assert "=== TV Shows ===" in result.stdout
+    assert "would be moved" in result.stdout
+    assert result.stdout.count("would be moved") == 1
+    assert list(target_dir.iterdir()) == []
+```
+
+Use the subprocess approach since `jellyfin-renamer.py` has a hyphen and can't be imported directly.
+
+- [ ] **Step 5: Run test**
+
+Run: `uv run python -m pytest test/test_renamer.py::test_dry_run_auto_mode_cli -v`
+Expected: PASS
+
+- [ ] **Step 6: Run full test suite**
+
+Run: `uv run python -m pytest test/test_renamer.py -v`
+Expected: All PASS
+
+- [ ] **Step 7: Manual smoke test**
+
+Run: `uv run python jellyfin-renamer.py --help`
+Expected: `--dry-run` appears in help output
+
+- [ ] **Step 8: Commit**
+
+```bash
+git add jellyfin-renamer.py test/test_renamer.py
+git commit -m "feat: add --dry-run CLI flag with grouped tree output"
+```
+
+---
+
+## Chunk 3: Final verification
+
+### Task 7: Full integration verification
+
+- [ ] **Step 1: Run full test suite**
+
+Run: `uv run python -m pytest test/test_renamer.py -v`
+Expected: All tests PASS
+
+- [ ] **Step 2: Manual end-to-end test (if test videos exist)**
+
+Run: `uv run python jellyfin-renamer.py test_videos/ /tmp/jf-test --dry-run`
+Expected: Grouped tree output, no files created in `/tmp/jf-test`
+
+- [ ] **Step 3: Verify `--dry-run` combined with `--downmix-audio`**
+
+Run: `uv run python jellyfin-renamer.py test_videos/ /tmp/jf-test --dry-run --downmix-audio`
+Expected: `[COPY + FFMPEG]` labels in output
+
+- [ ] **Step 4: Final commit if any cleanup needed**
+
+```bash
+git add core/dry_run.py core/movie_organizer.py core/tv_organizer.py jellyfin-renamer.py test/test_renamer.py
+git commit -m "chore: final cleanup for --dry-run feature"
+```

--- a/docs/superpowers/specs/2026-03-16-dry-run-design.md
+++ b/docs/superpowers/specs/2026-03-16-dry-run-design.md
@@ -17,10 +17,17 @@ uv run python jellyfin-renamer.py <source> <target> --dry-run [--content-type {m
 
 ### Refactor `prepare_*` functions to be pure
 
-Remove all `os.makedirs()` and `os.path.exists()` calls from `prepare_file_operations()` (movie_organizer.py) and `prepare_tv_operations()` (tv_organizer.py).
+Remove all `os.makedirs()` and `os.path.exists()` calls from:
 
-- Directory creation moves into the organizer functions, after prepare but before execute.
+- `prepare_file_operations()` in `movie_organizer.py`
+- `prepare_tv_operations()` in `tv_organizer.py`
+- `handle_duplicate_files()` in `tv_organizer.py` (also uses `os.path.exists()`)
+
+Changes:
+
+- Directory creation moves into the organizer functions, after prepare but before execute. The redundant directory creation pass already in the organizer loops can serve this purpose — remove the duplicated `os.makedirs` from prepare.
 - Duplicate target path detection switches from `os.path.exists()` to an in-memory set of seen paths, applying the counter logic without disk access.
+- All tqdm progress bars are skipped when `dry_run=True` — the branch happens right after grouping, before any tqdm-wrapped loops for directory creation or file operations.
 
 The prepare functions become: data in, operation list out.
 
@@ -57,6 +64,31 @@ Breaking Bad (2008)/
 3 files would be moved, 2 files would be copied + processed with FFmpeg
 ```
 
+**Auto mode (`--content-type auto`) output:**
+
+When auto-detecting, movies and TV shows appear under separate headings:
+```
+=== Movies ===
+
+Inception (2010)/
+  Inception (2010).mkv  <-  /src/inception.mkv  [MOVE]
+
+=== TV Shows ===
+
+Breaking Bad (2008)/
+  Season 01/
+    Breaking Bad S01E01.mkv  <-  /src/bb.s01e01.mkv  [MOVE]
+```
+
+If only one type is detected, only that heading appears. The summary line at the end covers all files across both types.
+
+**Edge case — no files found:**
+
+If the source directory contains no recognized video files, print:
+```
+No video files found in <source_dir>
+```
+
 ### Organizer flow
 
 ```
@@ -70,12 +102,15 @@ Both `organize_movies()` and `organize_tv_shows()` gain a `dry_run=False` parame
 
 ## Testing
 
-Tests in `test/test_renamer.py`:
+Tests in `test/test_renamer.py`, using `tmp_path` fixtures and `capsys` for stdout capture:
 
-- Verify `--dry-run` produces expected stdout for movie files
-- Verify `--dry-run` produces expected stdout for TV files
-- Verify `--dry-run` with `--downmix-audio` shows `[COPY + FFMPEG]` labels
-- Verify zero filesystem side effects (target dir remains empty)
-- Verify refactored `prepare_*` functions produce correct operation lists without disk access
+- **Dry-run movie output**: Create temp source with video files, run `organize_movies(dry_run=True)`, capture stdout, assert grouped tree format matches expected output.
+- **Dry-run TV output**: Same approach for `organize_tv_shows(dry_run=True)`.
+- **Dry-run auto mode**: Verify combined output with `=== Movies ===` / `=== TV Shows ===` headings.
+- **`--downmix-audio` labels**: Verify `[COPY + FFMPEG]` for main files vs `[MOVE]` for extras.
+- **Zero side effects**: Assert target directory is empty after dry-run (no dirs or files created).
+- **No files found**: Verify "No video files found" message for empty source dir.
+- **Pure prepare functions**: Call `prepare_file_operations()` and `prepare_tv_operations()` with test data, verify correct operation lists returned. "Without disk access" verified by using a non-existent target path — the function should not fail since it no longer touches the filesystem.
+- **In-memory duplicate detection**: Verify that when multiple files would map to the same target name, the counter suffix is applied correctly.
 
 No FFmpeg required for any dry-run tests.

--- a/docs/superpowers/specs/2026-03-16-dry-run-design.md
+++ b/docs/superpowers/specs/2026-03-16-dry-run-design.md
@@ -1,0 +1,81 @@
+# Design: `--dry-run` Option
+
+## Summary
+
+Add a `--dry-run` flag that shows what file operations would occur without touching the filesystem. Output is a grouped tree view printed to stdout with no progress bars.
+
+## CLI Interface
+
+```
+uv run python jellyfin-renamer.py <source> <target> --dry-run [--content-type {movies,tv,auto}] [--downmix-audio]
+```
+
+- `--dry-run` is combinable with all existing flags.
+- When active, zero filesystem side effects occur: no directories created, no files moved/copied, no FFmpeg invoked.
+
+## Approach: Pure Prepare Functions + Renderer
+
+### Refactor `prepare_*` functions to be pure
+
+Remove all `os.makedirs()` and `os.path.exists()` calls from `prepare_file_operations()` (movie_organizer.py) and `prepare_tv_operations()` (tv_organizer.py).
+
+- Directory creation moves into the organizer functions, after prepare but before execute.
+- Duplicate target path detection switches from `os.path.exists()` to an in-memory set of seen paths, applying the counter logic without disk access.
+
+The prepare functions become: data in, operation list out.
+
+### New module: `core/dry_run.py`
+
+A renderer function that takes operation lists and `downmix_audio` flag, prints a grouped tree to stdout.
+
+**Movie output format:**
+```
+Inception (2010)/
+  Inception (2010).mkv  <-  /src/inception.mkv  [MOVE]
+  Inception (2010) - 1080p.mkv  <-  /src/inception.1080p.mkv  [COPY + FFMPEG]
+  Trailers/
+    inception-trailer.mkv  <-  /src/inception-trailer.mkv  [MOVE]
+```
+
+**TV output format:**
+```
+Breaking Bad (2008)/
+  Season 01/
+    Breaking Bad S01E01.mkv  <-  /src/bb.s01e01.mkv  [MOVE]
+    Breaking Bad S01E02.mkv  <-  /src/bb.s01e02.mkv  [MOVE]
+  Season 02/
+    Breaking Bad S02E01.mkv  <-  /src/bb.s02e01.mkv  [COPY + FFMPEG]
+```
+
+**Operation labels:**
+- `[MOVE]` — default when `--downmix-audio` is off
+- `[COPY + FFMPEG]` — main files when `--downmix-audio` is on
+- `[MOVE]` — extras always (never FFmpeg-processed)
+
+**Summary line** at the end:
+```
+3 files would be moved, 2 files would be copied + processed with FFmpeg
+```
+
+### Organizer flow
+
+```
+scan -> group -> prepare (pure) -> dry_run ? render_dry_run() : create_dirs + execute
+```
+
+When `dry_run=True`: call renderer, return immediately.
+When `dry_run=False`: create directories, execute file operations as today.
+
+Both `organize_movies()` and `organize_tv_shows()` gain a `dry_run=False` parameter. `organize_mixed_content()` passes it through and skips top-level `Movies/`/`Shows/` directory creation when dry-running.
+
+## Testing
+
+Tests in `test/test_renamer.py`:
+
+- Verify `--dry-run` produces expected stdout for movie files
+- Verify `--dry-run` produces expected stdout for TV files
+- Verify `--dry-run` with `--downmix-audio` shows `[COPY + FFMPEG]` labels
+- Verify zero filesystem side effects (target dir remains empty)
+- Verify refactored `prepare_*` functions produce correct operation lists without disk access
+
+No FFmpeg required for any dry-run tests.

--- a/jellyfin-renamer.py
+++ b/jellyfin-renamer.py
@@ -17,8 +17,7 @@ async def organize_mixed_content(source_dir, target_dir, downmix_audio=False, dr
     all_files = scan_source_directory(source_dir, content_type="auto")
 
     if not all_files:
-        if dry_run:
-            print(f"No video files found in {source_dir}")
+        print(f"No video files found in {source_dir}")
         return
 
     # Separate files by detected type

--- a/jellyfin-renamer.py
+++ b/jellyfin-renamer.py
@@ -3,16 +3,23 @@ import asyncio
 import os
 
 from core.common import scan_source_directory
+from core.dry_run import print_dry_run_summary
 from core.movie_organizer import organize_movies
 from core.tv_organizer import organize_tv_shows
 
 
-async def organize_mixed_content(source_dir, target_dir, downmix_audio=False):
+async def organize_mixed_content(source_dir, target_dir, downmix_audio=False, dry_run=False):
     """Organize mixed content by auto-detecting content type."""
-    print("Scanning for mixed content...")
+    if not dry_run:
+        print("Scanning for mixed content...")
 
     # Scan files and auto-detect content types
     all_files = scan_source_directory(source_dir, content_type="auto")
+
+    if not all_files:
+        if dry_run:
+            print(f"No video files found in {source_dir}")
+        return
 
     # Separate files by detected type
     movie_files = [
@@ -24,24 +31,49 @@ async def organize_mixed_content(source_dir, target_dir, downmix_audio=False):
         (root, file) for root, file, content_type in all_files if content_type == "tv"
     ]
 
-    print(f"Found {len(movie_files)} movie files and {len(tv_files)} TV show files")
+    if not dry_run:
+        print(f"Found {len(movie_files)} movie files and {len(tv_files)} TV show files")
 
     # Create separate target directories
     movies_dir = os.path.join(target_dir, "Movies")
     shows_dir = os.path.join(target_dir, "Shows")
 
+    total_move = 0
+    total_ffmpeg = 0
+
     # Process movies if found
     if movie_files:
-        os.makedirs(movies_dir, exist_ok=True)
-        print("\n=== Processing Movies ===")
-        # Create a temporary source structure for movie organizer
-        await organize_movies(source_dir, movies_dir, downmix_audio)
+        if not dry_run:
+            os.makedirs(movies_dir, exist_ok=True)
+            print("\n=== Processing Movies ===")
+        else:
+            print("=== Movies ===\n")
+        result = await organize_movies(
+            source_dir, movies_dir, downmix_audio,
+            dry_run=dry_run, print_summary=not dry_run,
+        )
+        if dry_run and result:
+            total_move += result[0]
+            total_ffmpeg += result[1]
 
     # Process TV shows if found
     if tv_files:
-        os.makedirs(shows_dir, exist_ok=True)
-        print("\n=== Processing TV Shows ===")
-        await organize_tv_shows(source_dir, shows_dir, downmix_audio)
+        if not dry_run:
+            os.makedirs(shows_dir, exist_ok=True)
+            print("\n=== Processing TV Shows ===")
+        else:
+            print("\n=== TV Shows ===\n")
+        result = await organize_tv_shows(
+            source_dir, shows_dir, downmix_audio,
+            dry_run=dry_run, print_summary=not dry_run,
+        )
+        if dry_run and result:
+            total_move += result[0]
+            total_ffmpeg += result[1]
+
+    # Print combined summary for auto mode dry-run
+    if dry_run:
+        print_dry_run_summary(total_move, total_ffmpeg)
 
 
 if __name__ == "__main__":
@@ -60,17 +92,23 @@ if __name__ == "__main__":
         default=False,
         help="Downmix audio to stereo FLAC using FFmpeg (default: False)",
     )
+    parser.add_argument(
+        "--dry-run",
+        action="store_true",
+        default=False,
+        help="Show what would be done without making any changes",
+    )
     args = parser.parse_args()
 
     if args.content_type == "movies":
         asyncio.run(
-            organize_movies(args.source_dir, args.target_dir, args.downmix_audio)
+            organize_movies(args.source_dir, args.target_dir, args.downmix_audio, dry_run=args.dry_run)
         )
     elif args.content_type == "tv":
         asyncio.run(
-            organize_tv_shows(args.source_dir, args.target_dir, args.downmix_audio)
+            organize_tv_shows(args.source_dir, args.target_dir, args.downmix_audio, dry_run=args.dry_run)
         )
     else:  # auto
         asyncio.run(
-            organize_mixed_content(args.source_dir, args.target_dir, args.downmix_audio)
+            organize_mixed_content(args.source_dir, args.target_dir, args.downmix_audio, dry_run=args.dry_run)
         )

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "jellyfin-renamer"
-version = "0.1.0"
+version = "0.3.0"
 description = "parses media, organizes files"
 readme = "README.md"
 requires-python = ">=3.13"

--- a/test/test_renamer.py
+++ b/test/test_renamer.py
@@ -3,6 +3,7 @@
 Unit tests for jellyfin-renamer using pytest framework.
 """
 import shutil
+import subprocess
 import tempfile
 from pathlib import Path
 
@@ -569,3 +570,40 @@ async def test_tv_dry_run_no_side_effects(tmp_path):
 
     assert list(target_dir.iterdir()) == []
     assert (source_dir / "Breaking.Bad.S01E01.720p.BluRay.x264.mkv").exists()
+
+
+def test_dry_run_auto_mode_cli(tmp_path):
+    """Auto mode dry-run via CLI should show headings and combined summary."""
+    source_dir = tmp_path / "source"
+    target_dir = tmp_path / "target"
+    source_dir.mkdir()
+    target_dir.mkdir()
+
+    (source_dir / "Inception.2010.1080p.BluRay.mkv").write_bytes(b"\x00" * 100)
+    (source_dir / "Breaking.Bad.S01E01.720p.BluRay.x264.mkv").write_bytes(b"\x00" * 100)
+
+    result = subprocess.run(
+        ["uv", "run", "python", "jellyfin-renamer.py", str(source_dir), str(target_dir), "--dry-run"],
+        capture_output=True, text=True,
+        cwd="/Users/chris/GitHub/jellyfin-renamer/.worktrees/dry-run",
+    )
+    assert result.returncode == 0, f"CLI failed: {result.stderr}"
+    assert "=== Movies ===" in result.stdout
+    assert "=== TV Shows ===" in result.stdout
+    assert "would be moved" in result.stdout
+    assert result.stdout.count("would be moved") == 1
+    assert list(target_dir.iterdir()) == []
+
+
+@pytest.mark.asyncio
+async def test_dry_run_no_files_found(tmp_path, capsys):
+    """Dry-run on empty source should print 'No video files found'."""
+    source_dir = tmp_path / "source"
+    target_dir = tmp_path / "target"
+    source_dir.mkdir()
+    target_dir.mkdir()
+
+    await organize_movies(str(source_dir), str(target_dir), dry_run=True)
+
+    output = capsys.readouterr().out
+    assert "No video files found" in output

--- a/test/test_renamer.py
+++ b/test/test_renamer.py
@@ -2,6 +2,7 @@
 """
 Unit tests for jellyfin-renamer using pytest framework.
 """
+import pathlib
 import shutil
 import subprocess
 import tempfile
@@ -585,7 +586,7 @@ def test_dry_run_auto_mode_cli(tmp_path):
     result = subprocess.run(
         ["uv", "run", "python", "jellyfin-renamer.py", str(source_dir), str(target_dir), "--dry-run"],
         capture_output=True, text=True,
-        cwd="/Users/chris/GitHub/jellyfin-renamer/.worktrees/dry-run",
+        cwd=str(pathlib.Path(__file__).parent.parent),
     )
     assert result.returncode == 0, f"CLI failed: {result.stderr}"
     assert "=== Movies ===" in result.stdout
@@ -607,3 +608,54 @@ async def test_dry_run_no_files_found(tmp_path, capsys):
 
     output = capsys.readouterr().out
     assert "No video files found" in output
+
+
+def test_dry_run_movies_cli(tmp_path):
+    """--content-type movies --dry-run should show tree and exactly one summary line."""
+    source_dir = tmp_path / "source"
+    target_dir = tmp_path / "target"
+    source_dir.mkdir()
+    target_dir.mkdir()
+
+    (source_dir / "Inception.2010.1080p.BluRay.mkv").write_bytes(b"\x00" * 100)
+
+    result = subprocess.run(
+        [
+            "uv", "run", "python", "jellyfin-renamer.py",
+            str(source_dir), str(target_dir),
+            "--content-type", "movies", "--dry-run",
+        ],
+        capture_output=True, text=True,
+        cwd=str(pathlib.Path(__file__).parent.parent),
+    )
+    assert result.returncode == 0, f"CLI failed: {result.stderr}"
+    assert "Inception (2010)/" in result.stdout
+    assert "would be moved" in result.stdout
+    assert result.stdout.count("would be moved") == 1
+    assert list(target_dir.iterdir()) == []
+
+
+def test_dry_run_tv_cli(tmp_path):
+    """--content-type tv --dry-run should show tree and exactly one summary line."""
+    source_dir = tmp_path / "source"
+    target_dir = tmp_path / "target"
+    source_dir.mkdir()
+    target_dir.mkdir()
+
+    (source_dir / "Breaking.Bad.S01E01.720p.BluRay.x264.mkv").write_bytes(b"\x00" * 100)
+
+    result = subprocess.run(
+        [
+            "uv", "run", "python", "jellyfin-renamer.py",
+            str(source_dir), str(target_dir),
+            "--content-type", "tv", "--dry-run",
+        ],
+        capture_output=True, text=True,
+        cwd=str(pathlib.Path(__file__).parent.parent),
+    )
+    assert result.returncode == 0, f"CLI failed: {result.stderr}"
+    assert "Breaking Bad/" in result.stdout
+    assert "Season 01/" in result.stdout
+    assert "would be moved" in result.stdout
+    assert result.stdout.count("would be moved") == 1
+    assert list(target_dir.iterdir()) == []

--- a/test/test_renamer.py
+++ b/test/test_renamer.py
@@ -545,7 +545,8 @@ async def test_movie_dry_run_no_side_effects(tmp_path):
     # Create a dummy video file
     (source_dir / "Inception.2010.1080p.BluRay.mkv").write_bytes(b"\x00" * 100)
 
-    await organize_movies(str(source_dir), str(target_dir), dry_run=True)
+    result = await organize_movies(str(source_dir), str(target_dir), dry_run=True)
+    assert result == (1, 0)
 
     # Target should be empty
     assert list(target_dir.iterdir()) == []
@@ -563,7 +564,8 @@ async def test_tv_dry_run_no_side_effects(tmp_path):
 
     (source_dir / "Breaking.Bad.S01E01.720p.BluRay.x264.mkv").write_bytes(b"\x00" * 100)
 
-    await organize_tv_shows(str(source_dir), str(target_dir), dry_run=True)
+    result = await organize_tv_shows(str(source_dir), str(target_dir), dry_run=True)
+    assert result == (1, 0)
 
     assert list(target_dir.iterdir()) == []
     assert (source_dir / "Breaking.Bad.S01E01.720p.BluRay.x264.mkv").exists()

--- a/test/test_renamer.py
+++ b/test/test_renamer.py
@@ -532,3 +532,38 @@ def test_dry_run_extras_subfolder_tree(tmp_path, capsys):
 
     output = capsys.readouterr().out
     assert "trailers/" in output.lower()
+
+
+@pytest.mark.asyncio
+async def test_movie_dry_run_no_side_effects(tmp_path):
+    """Dry-run should not create any files or directories."""
+    source_dir = tmp_path / "source"
+    target_dir = tmp_path / "target"
+    source_dir.mkdir()
+    target_dir.mkdir()
+
+    # Create a dummy video file
+    (source_dir / "Inception.2010.1080p.BluRay.mkv").write_bytes(b"\x00" * 100)
+
+    await organize_movies(str(source_dir), str(target_dir), dry_run=True)
+
+    # Target should be empty
+    assert list(target_dir.iterdir()) == []
+    # Source file should still exist (not moved)
+    assert (source_dir / "Inception.2010.1080p.BluRay.mkv").exists()
+
+
+@pytest.mark.asyncio
+async def test_tv_dry_run_no_side_effects(tmp_path):
+    """Dry-run should not create any files or directories."""
+    source_dir = tmp_path / "source"
+    target_dir = tmp_path / "target"
+    source_dir.mkdir()
+    target_dir.mkdir()
+
+    (source_dir / "Breaking.Bad.S01E01.720p.BluRay.x264.mkv").write_bytes(b"\x00" * 100)
+
+    await organize_tv_shows(str(source_dir), str(target_dir), dry_run=True)
+
+    assert list(target_dir.iterdir()) == []
+    assert (source_dir / "Breaking.Bad.S01E01.720p.BluRay.x264.mkv").exists()

--- a/test/test_renamer.py
+++ b/test/test_renamer.py
@@ -10,7 +10,7 @@ import pytest
 
 from core.movie_organizer import group_files_by_movie, organize_movies, prepare_file_operations
 from core.movie_parser import parse_movie_info
-from core.tv_organizer import organize_tv_shows
+from core.tv_organizer import group_files_by_series, organize_tv_shows, prepare_tv_operations
 from core.tv_parser import detect_content_type, parse_tv_info
 
 
@@ -320,6 +320,25 @@ def test_prepare_file_operations_is_pure(tmp_path):
     for file_info, target_path in main_files:
         assert target_path.startswith(nonexistent_target)
     # The nonexistent dir should still not exist
+    assert not (tmp_path / "nonexistent").exists()
+
+
+def test_prepare_tv_operations_is_pure(tmp_path):
+    """prepare_tv_operations() should work without touching the filesystem."""
+    nonexistent_target = str(tmp_path / "nonexistent" / "deep" / "path")
+
+    all_files = [
+        (str(tmp_path), "Breaking.Bad.S01E01.720p.BluRay.x264.mkv"),
+        (str(tmp_path), "Breaking.Bad.S01E02.720p.BluRay.x264.mkv"),
+    ]
+    series_groups = group_files_by_series(all_files)
+    main_files, extra_files = prepare_tv_operations(series_groups, nonexistent_target)
+
+    assert len(main_files) == 2
+    assert len(extra_files) == 0
+    for file_info, target_path in main_files:
+        assert target_path.startswith(nonexistent_target)
+        assert "Season 01" in target_path
     assert not (tmp_path / "nonexistent").exists()
 
 

--- a/test/test_renamer.py
+++ b/test/test_renamer.py
@@ -8,7 +8,7 @@ from pathlib import Path
 
 import pytest
 
-from core.movie_organizer import organize_movies
+from core.movie_organizer import group_files_by_movie, organize_movies, prepare_file_operations
 from core.movie_parser import parse_movie_info
 from core.tv_organizer import organize_tv_shows
 from core.tv_parser import detect_content_type, parse_tv_info
@@ -300,6 +300,27 @@ async def test_tv_organization(temp_dirs):
         assert len(season_folders) > 0, "Should have at least one season folder"
     else:
         pytest.skip("No test videos found. Run create_test_videos.py first.")
+
+
+def test_prepare_file_operations_is_pure(tmp_path):
+    """prepare_file_operations() should work without touching the filesystem."""
+    # Use a target dir that does NOT exist — proves no os.makedirs/os.path.exists
+    nonexistent_target = str(tmp_path / "nonexistent" / "deep" / "path")
+
+    all_files = [
+        (str(tmp_path), "Inception.2010.1080p.BluRay.mkv"),
+        (str(tmp_path), "Inception.2010.720p.BluRay.mkv"),
+    ]
+    movie_groups = group_files_by_movie(all_files)
+    main_files, extra_files = prepare_file_operations(movie_groups, nonexistent_target)
+
+    assert len(main_files) == 2
+    assert len(extra_files) == 0
+    # Target paths should be under the nonexistent target dir
+    for file_info, target_path in main_files:
+        assert target_path.startswith(nonexistent_target)
+    # The nonexistent dir should still not exist
+    assert not (tmp_path / "nonexistent").exists()
 
 
 @pytest.mark.parametrize(

--- a/test/test_renamer.py
+++ b/test/test_renamer.py
@@ -10,7 +10,7 @@ import pytest
 
 from core.movie_organizer import group_files_by_movie, organize_movies, prepare_file_operations
 from core.movie_parser import parse_movie_info
-from core.tv_organizer import group_files_by_series, organize_tv_shows, prepare_tv_operations
+from core.tv_organizer import group_files_by_series, handle_duplicate_files, organize_tv_shows, prepare_tv_operations
 from core.tv_parser import detect_content_type, parse_tv_info
 
 
@@ -411,3 +411,28 @@ class TestExtensionHandling:
 
         assert base == "Show.S01E01.episode.name.with.dots.mov"
         assert ext == ".mkv"
+
+
+def test_movie_prepare_duplicate_detection(tmp_path):
+    """Duplicate movie files should get version suffixes via in-memory tracking."""
+    all_files = [
+        (str(tmp_path), "Inception.2010.1080p.BluRay.mkv"),
+        (str(tmp_path), "Inception.2010.1080p.WEB.mkv"),
+    ]
+    movie_groups = group_files_by_movie(all_files)
+    main_files, _ = prepare_file_operations(movie_groups, str(tmp_path / "target"))
+
+    paths = [t for _, t in main_files]
+    assert len(paths) == len(set(paths)), "All target paths should be unique"
+
+
+def test_tv_handle_duplicate_files_in_memory():
+    """handle_duplicate_files() should use in-memory set for dedup."""
+    seen = set()
+    path1 = handle_duplicate_files("/target/Show S01E01.mkv", seen)
+    path2 = handle_duplicate_files("/target/Show S01E01.mkv", seen)
+
+    assert path1 == "/target/Show S01E01.mkv"
+    assert path2 == "/target/Show S01E01_1.mkv"
+    assert path1 in seen
+    assert path2 in seen

--- a/test/test_renamer.py
+++ b/test/test_renamer.py
@@ -8,6 +8,7 @@ from pathlib import Path
 
 import pytest
 
+from core.dry_run import render_dry_run_movies, render_dry_run_tv
 from core.movie_organizer import group_files_by_movie, organize_movies, prepare_file_operations
 from core.movie_parser import parse_movie_info
 from core.tv_organizer import group_files_by_series, handle_duplicate_files, organize_tv_shows, prepare_tv_operations
@@ -436,3 +437,92 @@ def test_tv_handle_duplicate_files_in_memory():
     assert path2 == "/target/Show S01E01_1.mkv"
     assert path1 in seen
     assert path2 in seen
+
+
+def test_dry_run_movie_output(tmp_path, capsys):
+    """Dry-run should print grouped tree for movies."""
+    all_files = [
+        (str(tmp_path), "Inception.2010.1080p.BluRay.mkv"),
+    ]
+    movie_groups = group_files_by_movie(all_files)
+    target = str(tmp_path / "target")
+    main_files, extra_files = prepare_file_operations(movie_groups, target)
+
+    render_dry_run_movies(main_files, extra_files, target, downmix_audio=False)
+
+    output = capsys.readouterr().out
+    assert "Inception (2010)/" in output
+    assert "[MOVE]" in output
+    assert "Inception.2010.1080p.BluRay.mkv" in output or "Inception (2010)" in output
+    assert "would be moved" in output
+
+
+def test_dry_run_tv_output(tmp_path, capsys):
+    """Dry-run should print grouped tree for TV shows."""
+    all_files = [
+        (str(tmp_path), "Breaking.Bad.S01E01.720p.BluRay.x264.mkv"),
+        (str(tmp_path), "Breaking.Bad.S01E02.720p.BluRay.x264.mkv"),
+    ]
+    series_groups = group_files_by_series(all_files)
+    target = str(tmp_path / "target")
+    main_files, extra_files = prepare_tv_operations(series_groups, target)
+
+    render_dry_run_tv(main_files, extra_files, target, downmix_audio=False)
+
+    output = capsys.readouterr().out
+    assert "Breaking Bad/" in output
+    assert "Season 01/" in output
+    assert "[MOVE]" in output
+    assert "would be moved" in output
+
+
+def test_dry_run_ffmpeg_labels(tmp_path, capsys):
+    """Dry-run with downmix_audio should show [COPY + FFMPEG] for main files."""
+    all_files = [
+        (str(tmp_path), "Inception.2010.1080p.BluRay.mkv"),
+    ]
+    movie_groups = group_files_by_movie(all_files)
+    target = str(tmp_path / "target")
+    main_files, extra_files = prepare_file_operations(movie_groups, target)
+
+    render_dry_run_movies(main_files, extra_files, target, downmix_audio=True)
+
+    output = capsys.readouterr().out
+    assert "[COPY + FFMPEG]" in output
+    assert "would be copied + processed with FFmpeg" in output
+
+
+def test_dry_run_extras_always_move(tmp_path, capsys):
+    """Extras should show [MOVE] even when downmix_audio is True."""
+    all_files = [
+        (str(tmp_path), "Inception.2010.1080p.BluRay.mkv"),
+        (str(tmp_path), "The Matrix (1999) 1080p - Trailer.mkv"),
+    ]
+    movie_groups = group_files_by_movie(all_files)
+    target = str(tmp_path / "target")
+    main_files, extra_files = prepare_file_operations(movie_groups, target)
+
+    render_dry_run_movies(main_files, extra_files, target, downmix_audio=True)
+
+    output = capsys.readouterr().out
+    # Main files get COPY + FFMPEG
+    assert "[COPY + FFMPEG]" in output
+    # Find the trailers line — it should say [MOVE], not [COPY + FFMPEG]
+    for line in output.splitlines():
+        if ("trailers/" in line.lower() and "<-" in line) or ("Trailer" in line and "<-" in line):
+            assert "[MOVE]" in line, f"Extras should always be [MOVE], got: {line}"
+
+
+def test_dry_run_extras_subfolder_tree(tmp_path, capsys):
+    """Extras should appear under their subfolder in the tree."""
+    all_files = [
+        (str(tmp_path), "The Matrix (1999) 1080p - Trailer.mkv"),
+    ]
+    movie_groups = group_files_by_movie(all_files)
+    target = str(tmp_path / "target")
+    main_files, extra_files = prepare_file_operations(movie_groups, target)
+
+    render_dry_run_movies(main_files, extra_files, target, downmix_audio=False)
+
+    output = capsys.readouterr().out
+    assert "trailers/" in output.lower()

--- a/test/test_renamer.py
+++ b/test/test_renamer.py
@@ -507,10 +507,16 @@ def test_dry_run_extras_always_move(tmp_path, capsys):
     output = capsys.readouterr().out
     # Main files get COPY + FFMPEG
     assert "[COPY + FFMPEG]" in output
-    # Find the trailers line — it should say [MOVE], not [COPY + FFMPEG]
-    for line in output.splitlines():
-        if ("trailers/" in line.lower() and "<-" in line) or ("Trailer" in line and "<-" in line):
-            assert "[MOVE]" in line, f"Extras should always be [MOVE], got: {line}"
+    # Verify extras were detected
+    assert len(extra_files) > 0, "Trailer should be classified as an extra"
+    # Find trailer output lines and verify they show [MOVE]
+    trailer_lines = [
+        line for line in output.splitlines()
+        if "<-" in line and ("trailers/" in line.lower() or "Trailer" in line)
+    ]
+    assert trailer_lines, "Expected at least one trailer output line"
+    for line in trailer_lines:
+        assert "[MOVE]" in line, f"Extras should always be [MOVE], got: {line}"
 
 
 def test_dry_run_extras_subfolder_tree(tmp_path, capsys):


### PR DESCRIPTION
## Summary

- Add `--dry-run` CLI flag that shows what file operations would occur without touching the filesystem
- Refactor `prepare_file_operations()` and `prepare_tv_operations()` to be pure functions (no filesystem calls), enabling zero-side-effect preview
- Add `core/dry_run.py` renderer that formats operation lists as grouped trees with `[MOVE]` / `[COPY + FFMPEG]` labels and a summary line

## Details

**Architecture:** `scan → group → prepare (pure) → dry_run ? render : create_dirs + execute`

When `--dry-run` is active:
- No directories are created, no files are moved/copied, no FFmpeg is invoked
- Output is a grouped tree per folder/series with source paths and operation labels
- `--downmix-audio` combined with `--dry-run` shows `[COPY + FFMPEG]` labels for main files
- Auto mode (`--content-type auto`) shows `=== Movies ===` / `=== TV Shows ===` headings with one combined summary line

## Test Plan

- [x] `test_prepare_file_operations_is_pure` — pure function works with non-existent target
- [x] `test_prepare_tv_operations_is_pure` — same for TV
- [x] `test_movie_dry_run_no_side_effects` — target dir stays empty after dry-run
- [x] `test_tv_dry_run_no_side_effects` — same for TV
- [x] `test_dry_run_movie_output` / `test_dry_run_tv_output` — tree output format
- [x] `test_dry_run_ffmpeg_labels` — `[COPY + FFMPEG]` when `--downmix-audio`
- [x] `test_dry_run_extras_always_move` — extras always `[MOVE]`
- [x] `test_dry_run_auto_mode_cli` — combined summary, single "would be moved" line
- [x] `test_dry_run_movies_cli` / `test_dry_run_tv_cli` — single-type CLI paths
- [x] 45 tests passing, 2 skipped (FFmpeg integration tests)

🤖 Generated with [Claude Code](https://claude.com/claude-code)